### PR TITLE
feat : 캘린더 유저 정보 저장 기능 추가

### DIFF
--- a/src/main/java/com/example/swithme/controller/CalendarController.java
+++ b/src/main/java/com/example/swithme/controller/CalendarController.java
@@ -1,8 +1,12 @@
 package com.example.swithme.controller;
 
 import com.example.swithme.entity.Calendar;
+import com.example.swithme.entity.User;
 import com.example.swithme.repository.CalendarRepository;
+import com.example.swithme.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,13 +18,15 @@ import java.util.List;
 import java.util.Optional;
 
 @Controller
+@RequiredArgsConstructor
 public class CalendarController {
-    @Autowired
-    private CalendarRepository studyRepository;
+
+    private final CalendarRepository studyRepository;
 
     @GetMapping("/studies")
-    public String listStudies(Model model) {
-        List<Calendar> studies = studyRepository.findAll();
+    public String listStudies(Model model, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        User user = userDetails.getUser();
+        List<Calendar> studies = studyRepository.findAllByUser(user);
         model.addAttribute("studies", studies);
         return "study/list";
     }
@@ -32,14 +38,18 @@ public class CalendarController {
     }
 
     @PostMapping("/studies")
-    public String createStudy(@ModelAttribute Calendar study) {
+    public String createStudy(@ModelAttribute Calendar study, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        User user = userDetails.getUser();
+        study.setUser(user);
+
         studyRepository.save(study);
         return "redirect:/studies";
     }
 
     @GetMapping("/studies/calendar")
-    public String showCalendar(Model model) {
-        List<Calendar> studies = studyRepository.findAll();
+    public String showCalendar(Model model, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        User user = userDetails.getUser();
+        List<Calendar> studies = studyRepository.findAllByUser(user);
         model.addAttribute("studies", studies);
         return "study/calendar";
     }

--- a/src/main/java/com/example/swithme/entity/Calendar.java
+++ b/src/main/java/com/example/swithme/entity/Calendar.java
@@ -2,6 +2,7 @@ package com.example.swithme.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Setter
+@NoArgsConstructor
 public class Calendar {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -18,9 +20,16 @@ public class Calendar {
     private LocalDateTime startTime;
     private LocalDateTime endTime;
 
-    @OneToOne
-    @JoinColumn(name = "user_id", unique = true)
+    @ManyToOne
+    @JoinColumn(name = "user_id")
     private User user;
+
+    public Calendar(String name, LocalDateTime startTime, LocalDateTime endTime, User user) {
+        this.name = name;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.user = user;
+    }
 }
 
 

--- a/src/main/java/com/example/swithme/repository/CalendarRepository.java
+++ b/src/main/java/com/example/swithme/repository/CalendarRepository.java
@@ -1,8 +1,13 @@
 package com.example.swithme.repository;
 
 import com.example.swithme.entity.Calendar;
+import com.example.swithme.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CalendarRepository extends JpaRepository<Calendar, Long> {
+
+    List<Calendar> findAllByUser(User user);
 }
 

--- a/src/main/resources/templates/study/calendar.html
+++ b/src/main/resources/templates/study/calendar.html
@@ -54,7 +54,9 @@
 <div>
   <button type="button" class="btn btn-secondary" onclick="location.href='/studies/new'">일정 작성하기</button>
 </div>
+
 <div id="calendar"></div>
+
 <div class="modal fade" id="study-details-modal" tabindex="-1" role="dialog" aria-labelledby="study-details-modal-label" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">


### PR DESCRIPTION
- 유저랑 캘린더 관계 1대1에서 1대다로 변경 : 유저가 여러개의 캘린더일정을 가짐. 

- 필드 주입에서 생성자 주입으로 변경 
 
- 캘린더 작성시 : 유저 정보 추가(근데 받을 때 엔티티로 바로 받으면 안되고 dto 사용해야 할듯.)

- 캘린더 작성 후 리스트 보여주는 부분 : 로그인한 유저 일정만 보이게 변경

-전체 캘린더 : 보이는 부분에 로그인 유저만 보이게 변경

그외에도 변경할게 있을 것 같기는 합니다. 